### PR TITLE
Fix/issue 3 4 search improvements

### DIFF
--- a/script/gatherData.js
+++ b/script/gatherData.js
@@ -43,7 +43,7 @@ module.exports = {
       let url =
         'https://raw.githubusercontent.com/' +
         apiData.full_name +
-        '/master/' +
+        '/' + apiData.default_branch + '/' +   // ← dinâmico!
         fileName
 
       // DNS lookup errors at random causing stop to program
@@ -52,7 +52,7 @@ module.exports = {
       try {
         fileRaw = await Fetch(url)
       } catch (err) {
-        await new Promise((resolve) => setTimeout(resolve, 7777))
+        await new Promise((resolve) => setTimeout(resolve, 1000))
         try {
           fileRaw = await Fetch(url)
         } catch (err) {

--- a/script/gatherData.js
+++ b/script/gatherData.js
@@ -43,7 +43,7 @@ module.exports = {
       let url =
         'https://raw.githubusercontent.com/' +
         apiData.full_name +
-        '/' + apiData.default_branch + '/' +   // ← dinâmico!
+        '/' + apiData.default_branch + '/' +
         fileName
 
       // DNS lookup errors at random causing stop to program

--- a/script/search.js
+++ b/script/search.js
@@ -1,68 +1,71 @@
 module.exports = {
-  search: async function () {
-    // Node modules
+  search: async function (githubToken = null) {
+    const Fetch = require('node-fetch')
     const today = new Date()
     const thisYear = today.getFullYear()
 
-    // External modules
-    const Fetch = require('node-fetch')
-
     console.log('\nSearch function initiated.\n')
+    const startTime = Date.now()
 
     let searchResults = []
-    let nbRepos = 0
 
-    // increment year to search (start: 2010)
-    for (let year = 2010; year <= thisYear; year++) {
-      // increment page of search results + reset nbRepos for each year
-      nbRepos = 0
-      for (let page = 1; page <= 10; page++) {
-        await new Promise((resolve) => setTimeout(resolve, 7777))
-
-        let searchURL =
-          'https://api.github.com/search/repositories?q=seneca-+created:%3C' +
-          year +
-          '-01-01&page=' +
-          page +
-          '&per_page=100'
-
-        const response = await Fetch(searchURL)
-        const body = await response.text()
-        const json = JSON.parse(body)
-        // catching error
-        if (!response.ok) {
-          console.info('Error fetching results from ', year, ' page ', page)
-          continue
-        }
-
-        console.log(
-          '[',
-          year,
-          '| pg',
-          page,
-          ']',
-          json.items.length,
-          'results fetched... '
-        )
-
-        json.items.forEach((item) => {
-          searchResults.push(item)
-          nbRepos++
-        })
-
-        if (json.total_count <= 100) {
-          break
-        }
-
-        if (json.items.length == 0) {
-          break
-        }
-      }
-
-      console.log('[', year, ':', nbRepos, 'results mapped. ]')
+    const headers = {}
+    if (githubToken) {
+      headers['Authorization'] = `token ${githubToken}`
+      console.log('Using GitHub token — rate limit: 5000 req/hour')
+    } else {
+      console.log('No token — rate limit: 60 req/hour (slow mode)')
     }
 
-    console.log('\nSearch completed.', searchResults.length, 'repos total.')
+    for (let year = 2010; year <= thisYear; year++) {
+      let nbRepos = 0
+
+      for (let page = 1; page <= 10; page++) {
+        const delay = githubToken ? 200 : 3000
+        await new Promise((resolve) => setTimeout(resolve, delay))
+
+        const searchURL =
+          `https://api.github.com/search/repositories` +
+          `?q=seneca-+created:${year}-01-01..${year}-12-31` +
+          `&page=${page}&per_page=100`
+
+        let response
+        try {
+          response = await Fetch(searchURL, { headers })
+        } catch (err) {
+          console.error(`Network error on ${year} page ${page}:`, err.message)
+          break
+        }
+
+        const remaining = parseInt(response.headers.get('x-ratelimit-remaining') || '999')
+        if (remaining < 5) {
+          const resetAt = parseInt(response.headers.get('x-ratelimit-reset') || '0')
+          const waitMs = Math.max((resetAt * 1000) - Date.now(), 0) + 1000
+          console.warn(`Rate limit! Waiting ${Math.ceil(waitMs/1000)}s...`)
+          await new Promise((resolve) => setTimeout(resolve, waitMs))
+        }
+
+        if (!response.ok) {
+          console.info(`Error ${response.status} on year ${year} page ${page}`)
+          break
+        }
+
+        const json = await response.json()
+        console.log(`[ ${year} | pg ${page} ] ${json.items.length} results fetched...`)
+
+        json.items.forEach((item) => searchResults.push(item))
+        nbRepos += json.items.length
+
+        if (json.items.length === 0) break
+
+        if (json.total_count <= 100) break
+      }
+
+      console.log(`[ ${year}: ${nbRepos} results mapped. ]`)
+    }
+
+    const elapsed = ((Date.now() - startTime) / 1000).toFixed(1)
+    console.log(`\nSearch completed. ${searchResults.length} repos found in ${elapsed}s\n`)
 
     return searchResults
   },


### PR DESCRIPTION
## What changed
- Replace fixed 7777ms delay with smart delay (200ms with token, 3000ms without)
- Add `githubToken` parameter to support optional authentication
- Fix search query to use date range per year instead of less-than operator
- Add early exit when `items.length === 0` to avoid unnecessary requests
- Add rate limit detection using `x-ratelimit-remaining` header
- Add execution timer to track total search duration

## Why
The original 7777ms fixed delay caused ~20 minutes of pure waiting time per run.
The broken query (less-than operator) was returning duplicate repos across years.