### PR TITLE
Feat/issue 7 parallel gatherdata

### DIFF
--- a/repo-maintain.js
+++ b/repo-maintain.js
@@ -6,6 +6,8 @@ const { createReport } = require('./script/createReport')
 repoMaintain()
 
 async function repoMaintain() {
+  const startTime = Date.now()
+
   if (2 < process.argv.length && 'silent' == process.argv[2]) {
     console.log = function () {}
   }
@@ -16,7 +18,8 @@ async function repoMaintain() {
   let checkResults = await runChecks(Plugins)
   await createReport(checkResults)
 
+  const elapsed = ((Date.now() - startTime) / 1000 / 60).toFixed(1)
   console.info(
-    'Process complete. See REPORT files for details - available in Markdown and CSV formats.'
+    `Process complete. See REPORT files for details - available in Markdown and CSV formats.\nTotal time: ${elapsed} minutes`
   )
 }

--- a/repo-maintain.js
+++ b/repo-maintain.js
@@ -10,7 +10,8 @@ async function repoMaintain() {
     console.log = function () {}
   }
 
-  let searchResults = await search()
+  const githubToken = process.env.GITHUB_TOKEN || null
+  let searchResults = await search(githubToken)
   let Plugins = await filter(searchResults)
   let checkResults = await runChecks(Plugins)
   await createReport(checkResults)

--- a/script/gatherData.js
+++ b/script/gatherData.js
@@ -1,10 +1,7 @@
 module.exports = {
   gatherData: async function (apiData, checkList) {
-    // Node modules
     const Path = require('path')
-
-    // External modules
-    const Fetch = require('node-fetch') // v3 only supports ESM - switch?
+    const Fetch = require('node-fetch')
 
     let reqData = {}
     reqData.full_name = apiData.full_name
@@ -21,7 +18,6 @@ module.exports = {
       case 'JavaScript':
         config.push('js')
         break
-
       case 'TypeScript':
         config.push('ts')
         break
@@ -36,48 +32,60 @@ module.exports = {
         relCheckList[checkName] = checkDetails
       }
     }
-    for (let i = 0; i < Object.keys(filesReq).length; i++) {
-      let fileName = Object.keys(filesReq)[i]
-      let fileContent = null
-      if (null == fileName) continue
-      let url =
+
+    // Fetches a single file and returns { fileName, fileContent } or null on failure
+    const fetchFile = async (fileName) => {
+      if (null == fileName) return null
+
+      const url =
         'https://raw.githubusercontent.com/' +
         apiData.full_name +
-        '/' + apiData.default_branch + '/' +   // ← dinâmico!
+        '/' + apiData.default_branch + '/' +
         fileName
 
-      // DNS lookup errors at random causing stop to program
-      // If fetch request fails, wait - try again - move on if unsuccessful
-      let fileRaw = Promise
+      let fileRaw
       try {
         fileRaw = await Fetch(url)
       } catch (err) {
+        // DNS lookup errors may occur randomly - wait and retry once before giving up
         await new Promise((resolve) => setTimeout(resolve, 1000))
         try {
           fileRaw = await Fetch(url)
         } catch (err) {
-          continue
+          return null
         }
       }
 
-      if (fileRaw.ok) {
-        if ('.json' == Path.extname(url)) {
-          try {
-            fileContent = await fileRaw.json()
-          } catch (err) {
-            continue
-          }
-        } else {
-          fileContent = await fileRaw.text()
-        }
-        reqData[fileName] = fileContent
+      if (!fileRaw.ok) return null
 
-        // getting package name
-        if ('package.json' == fileName) {
-          reqData.package_name = fileContent.name
+      let fileContent
+      if ('.json' == Path.extname(url)) {
+        try {
+          fileContent = await fileRaw.json()
+        } catch (err) {
+          return null
         }
+      } else {
+        fileContent = await fileRaw.text()
       }
+
+      return { fileName, fileContent }
     }
+
+    // Fetch all files in parallel instead of sequentially
+    const fileNames = Object.keys(filesReq)
+    const results = await Promise.all(fileNames.map(fetchFile))
+
+    // Process results and populate reqData
+    results.forEach((result) => {
+      if (result == null) return
+      reqData[result.fileName] = result.fileContent
+
+      // Extract package name from package.json
+      if ('package.json' == result.fileName) {
+        reqData.package_name = result.fileContent.name
+      }
+    })
 
     return {
       data: reqData,

--- a/script/gatherData.js
+++ b/script/gatherData.js
@@ -43,7 +43,7 @@ module.exports = {
       let url =
         'https://raw.githubusercontent.com/' +
         apiData.full_name +
-        '/master/' +
+        '/' + apiData.default_branch + '/' +   // ← dinâmico!
         fileName
 
       // DNS lookup errors at random causing stop to program
@@ -52,7 +52,7 @@ module.exports = {
       try {
         fileRaw = await Fetch(url)
       } catch (err) {
-        await new Promise((resolve) => setTimeout(resolve, 7777))
+        await new Promise((resolve) => setTimeout(resolve, 1000))
         try {
           fileRaw = await Fetch(url)
         } catch (err) {

--- a/script/search.js
+++ b/script/search.js
@@ -1,68 +1,71 @@
 module.exports = {
-  search: async function () {
-    // Node modules
+  search: async function (githubToken = null) {
+    const Fetch = require('node-fetch')
     const today = new Date()
     const thisYear = today.getFullYear()
 
-    // External modules
-    const Fetch = require('node-fetch')
-
     console.log('\nSearch function initiated.\n')
+    const startTime = Date.now()
 
     let searchResults = []
-    let nbRepos = 0
 
-    // increment year to search (start: 2010)
-    for (let year = 2010; year <= thisYear; year++) {
-      // increment page of search results + reset nbRepos for each year
-      nbRepos = 0
-      for (let page = 1; page <= 10; page++) {
-        await new Promise((resolve) => setTimeout(resolve, 7777))
-
-        let searchURL =
-          'https://api.github.com/search/repositories?q=seneca-+created:%3C' +
-          year +
-          '-01-01&page=' +
-          page +
-          '&per_page=100'
-
-        const response = await Fetch(searchURL)
-        const body = await response.text()
-        const json = JSON.parse(body)
-        // catching error
-        if (!response.ok) {
-          console.info('Error fetching results from ', year, ' page ', page)
-          continue
-        }
-
-        console.log(
-          '[',
-          year,
-          '| pg',
-          page,
-          ']',
-          json.items.length,
-          'results fetched... '
-        )
-
-        json.items.forEach((item) => {
-          searchResults.push(item)
-          nbRepos++
-        })
-
-        if (json.total_count <= 100) {
-          break
-        }
-
-        if (json.items.length == 0) {
-          break
-        }
-      }
-
-      console.log('[', year, ':', nbRepos, 'results mapped. ]')
+    const headers = {}
+    if (githubToken) {
+      headers['Authorization'] = `token ${githubToken}`
+      console.log('Using GitHub token — rate limit: 5000 req/hour')
+    } else {
+      console.log('No token — rate limit: 60 req/hour (slow mode)')
     }
 
-    console.log('\nSearch completed.', searchResults.length, 'repos total.')
+    for (let year = 2010; year <= thisYear; year++) {
+      let nbRepos = 0
+
+      for (let page = 1; page <= 10; page++) {
+        const delay = githubToken ? 200 : 3000
+        await new Promise((resolve) => setTimeout(resolve, delay))
+
+        const searchURL =
+          `https://api.github.com/search/repositories` +
+          `?q=seneca-+created:${year}-01-01..${year}-12-31` +
+          `&page=${page}&per_page=100`
+
+        let response
+        try {
+          response = await Fetch(searchURL, { headers })
+        } catch (err) {
+          console.error(`Network error on ${year} page ${page}:`, err.message)
+          break
+        }
+
+        const remaining = parseInt(response.headers.get('x-ratelimit-remaining') || '999')
+        if (remaining < 5) {
+          const resetAt = parseInt(response.headers.get('x-ratelimit-reset') || '0')
+          const waitMs = Math.max((resetAt * 1000) - Date.now(), 0) + 1000
+          console.warn(`Rate limit! Waiting ${Math.ceil(waitMs/1000)}s...`)
+          await new Promise((resolve) => setTimeout(resolve, waitMs))
+        }
+
+        if (!response.ok) {
+          console.info(`Error ${response.status} on year ${year} page ${page}`)
+          break
+        }
+
+        const json = await response.json()
+        console.log(`[ ${year} | pg ${page} ] ${json.items.length} results fetched...`)
+
+        json.items.forEach((item) => searchResults.push(item))
+        nbRepos += json.items.length
+
+        if (json.items.length === 0) break
+
+        if (json.total_count <= 100) break
+      }
+
+      console.log(`[ ${year}: ${nbRepos} results mapped. ]`)
+    }
+
+    const elapsed = ((Date.now() - startTime) / 1000).toFixed(1)
+    console.log(`\nSearch completed. ${searchResults.length} repos found in ${elapsed}s\n`)
 
     return searchResults
   },


### PR DESCRIPTION
## What changed
- Extract file fetch logic into `fetchFile()` async function
- Replace sequential `for` loop with `Promise.all()` for parallel fetching
- All files for a plugin are now fetched simultaneously instead of one by one
- Reduces file fetch time per plugin from O(n) to O(1)

## Why
Each plugin requires multiple files (README.md, package.json, LICENSE, etc).
Fetching them sequentially means waiting for each request to finish before
starting the next. With Promise.all(), all requests fire simultaneously.