### PR TITLE
fix: update exist_dist check to verify types field in package.json

### DIFF
--- a/checks/checks.js
+++ b/checks/checks.js
@@ -15,12 +15,10 @@ module.exports = {
 
     exist_dist: {
       config: 'ts',
-      kind: 'fileX_exist_if_contain_json',
-      fileX: '',
+      kind: 'content_contain_json',
       file: 'package.json',
-      contains: ['main'],
+      contains: ['types'],
       contains_type: 'key',
-      contains_is_not: 'dist/index.js',
     },
 
     exist_entry: {


### PR DESCRIPTION
## Problem

The `exist_dist` check was incorrectly configured for TypeScript projects. It was checking for a `main` field in package.json and verifying it wasn't `dist/index.js`, which doesn't align with TypeScript project structure validation.

TypeScript projects should have a `types` field pointing to their type definitions file, not use the generic main field validation.

## Fix

- Changed `exist_dist` check from `fileX_exist_if_contain_json` to `content_contain_json`
- Updated target field from `main` to `types` for proper TypeScript validation
- Removed unnecessary `fileX` and `contains_is_not` properties that don't apply to this check

## Impact

The `exist_dist` check now correctly validates TypeScript projects by ensuring they have a `types` field in package.json, improving accuracy of repo validation for TypeScript packages.